### PR TITLE
Updated ETF install file for OSGeoLive 17 to work with new OS and Java version

### DIFF
--- a/bin/install_etf.sh
+++ b/bin/install_etf.sh
@@ -2,7 +2,7 @@
 #############################################################################
 #
 # Purpose: This script will install INSPIRE ETF
-# Author:  Guadalter <guadaltel.com> | Daniel Martín Pérez de León <danielmartin@guadaltel.com>
+# Author:  Guadaltel <guadaltel.com> | Daniel Martín Pérez de León <danielmartin@guadaltel.com>
 # Version 2024-09-20
 #
 #############################################################################

--- a/bin/install_etf.sh
+++ b/bin/install_etf.sh
@@ -2,8 +2,8 @@
 #############################################################################
 #
 # Purpose: This script will install INSPIRE ETF
-# Author:
-# Version 2020-08-28
+# Author:  
+# Version 2024-09-20
 #
 #############################################################################
 # Copyright (c) 2011-2019 The Open Source Geospatial Foundation and others.
@@ -33,7 +33,7 @@ START=$(date +%M:%S)
 BUILD_DIR=`pwd`
 TMP="/tmp/build_etf"
 if [ -z "$USER_NAME" ] ; then
-   USER_NAME="user"
+   USER_NAME=$(whoami)
 fi
 USER_HOME="/home/$USER_NAME"
 JETTY9_SCRIPT_NAME="jetty9"
@@ -47,7 +47,7 @@ ETF_FOLDER="$USER_HOME/.etf"
 ETF_WAR_INSTALL_FOLDER="/usr/share/$JETTY9_SCRIPT_NAME/webapps"
 ETF_BIN_FOLDER="/usr/local/share/ETF"
 ETF_VERSION="2.0"
-JAVA_PKG="openjdk-8-jdk-headless"
+JAVA_PKG="openjdk-11-jdk-headless"
 JETTY9_HOME="/usr/share/$JETTY9_SCRIPT_NAME"
 
 # -----------------------------------------------------------------------------
@@ -80,11 +80,26 @@ echo "JAVA_PKG: $JAVA_PKG"
 #
 # 1 Check for OpenJDK
 #
-apt-get update
-if [ ! -x "`which java`" ] ; then
-    apt-get -q update
-    apt-get --assume-yes install $JAVA_PKG
+apt-get -qq update
+
+# Check if openjdk-8-jdk-headless is installed
+if dpkg -l | grep -q "$JAVA_PKG"; then
+    echo "$JAVA_PKG is installed."
+else
+    echo "$JAVA_PKG is not installed. Installing now..."
+    apt-get --assume-yes install "$JAVA_PKG"
 fi
+
+# Set JAVA system version to 1.8
+update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+
+
+# Get and echo the Java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+echo "Java version is: $JAVA_VERSION"
+echo "########"
+
 #
 #
 # 2 JETTY9
@@ -115,8 +130,8 @@ fi
 # create the TMP directory and download the ETF git repository
 mkdir -p "$TMP"
 cd "$TMP"
-wget -c --no-check-certificate https://github.com/etf-validator/OSGeoLive-ETF/releases/download/OSGeoLive15.0/ETF.war
-wget -c --no-check-certificate https://github.com/etf-validator/OSGeoLive-ETF/releases/download/OSGeoLive15.0/ets-repository-osgeolive-15.zip
+wget -c --no-check-certificate https://github.com/etf-validator/OSGeoLive-ETF/releases/download/OSGeoLive17.0/ETF.war
+wget -c --no-check-certificate https://github.com/etf-validator/OSGeoLive-ETF/releases/download/OSGeoLive17.0/ets-repository-osgeolive-17.zip
 
 #
 # copy logo
@@ -149,12 +164,12 @@ rm -rf "$ETF_FOLDER"
 # It puts the ETS repository to its place
 #
 sudo sed -i "s/jetty.http.port=8080/jetty.http.port=$ETF_PORT/g" "$JETTY9_HOME/start.ini"
-sudo -u user /usr/share/jetty9/bin/jetty.sh start
+sudo -u "$USER_NAME" /usr/share/jetty9/bin/jetty.sh start
 wait
-sudo -u user /usr/share/jetty9/bin/jetty.sh stop
-if [ ! -d "$ETF_FOLDER/projects/ets-repository-osgeolive-15" ];then
+sudo -u "$USER_NAME" /usr/share/jetty9/bin/jetty.sh stop
+if [ ! -d "$ETF_FOLDER/projects/ets-repository-osgeolive-17" ];then
 	cd "$ETF_FOLDER/projects/"
-	sudo unzip -o "$TMP/ets-repository-osgeolive-15.zip"
+	sudo unzip -o "$TMP/ets-repository-osgeolive-17.zip"
 fi
 #
 # It makes modifiable the folder containing jetty for it to work perfectly
@@ -174,6 +189,16 @@ sudo chmod 777 "$ETF_BIN_FOLDER/"
 if [ ! -e $ETF_BIN_FOLDER/etf-start.sh ] ; then
     cat << EOF > $ETF_BIN_FOLDER/etf-start.sh
 #!/bin/bash
+
+# Set Java to OpenJDK 8
+update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+
+
+# Echo the Java version to verify
+JAVA_VERSION=\$(java -version 2>&1 | head -n 1)
+echo "Using Java version: \$JAVA_VERSION"
+
 SERVICEJETTY=\`systemctl status jetty9 | grep "Active: active" | wc -l\`
 if [ \$SERVICEJETTY -eq 1 ]; then
 	systemctl stop jetty9
@@ -199,6 +224,17 @@ fi
 if [ ! -e $ETF_BIN_FOLDER/etf-stop.sh ] ; then
    sudo cat << EOF > $ETF_BIN_FOLDER/etf-stop.sh
 #!/bin/bash
+
+# Set Java to OpenJDK 8
+update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+
+
+# Echo the Java version to verify
+JAVA_VERSION=\$(java -version 2>&1 | head -n 1)
+echo "Using Java version: \$JAVA_VERSION"
+
+
 JETTY9=\`/usr/share/jetty9/bin/jetty.sh status | grep "Jetty running pid=" | wc -l\`
 if [ \$JETTY9 -eq 1 ]; then
     /usr/share/jetty9/bin/jetty.sh stop
@@ -261,4 +297,3 @@ sudo chmod 755 "/usr/share/applications/"
 ####
 "$BUILD_DIR"/diskspace_probe.sh "`basename $0`" end
 echo -e "Timing:\nStart: $START\nEnd  : $(date +%M:%S)"
-

--- a/bin/install_etf.sh
+++ b/bin/install_etf.sh
@@ -2,7 +2,7 @@
 #############################################################################
 #
 # Purpose: This script will install INSPIRE ETF
-# Author:  
+# Author:  Guadalter <guadaltel.com> | Daniel Martín Pérez de León <danielmartin@guadaltel.com>
 # Version 2024-09-20
 #
 #############################################################################
@@ -82,7 +82,7 @@ echo "JAVA_PKG: $JAVA_PKG"
 #
 apt-get -qq update
 
-# Check if openjdk-8-jdk-headless is installed
+# Check if openjdk-11-jdk-headless is installed
 if dpkg -l | grep -q "$JAVA_PKG"; then
     echo "$JAVA_PKG is installed."
 else
@@ -90,7 +90,7 @@ else
     apt-get --assume-yes install "$JAVA_PKG"
 fi
 
-# Set JAVA system version to 1.8
+# Set JAVA system version to 11
 update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
@@ -190,7 +190,7 @@ if [ ! -e $ETF_BIN_FOLDER/etf-start.sh ] ; then
     cat << EOF > $ETF_BIN_FOLDER/etf-start.sh
 #!/bin/bash
 
-# Set Java to OpenJDK 8
+# Set Java to OpenJDK 11
 update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
@@ -225,7 +225,7 @@ if [ ! -e $ETF_BIN_FOLDER/etf-stop.sh ] ; then
    sudo cat << EOF > $ETF_BIN_FOLDER/etf-stop.sh
 #!/bin/bash
 
-# Set Java to OpenJDK 8
+# Set Java to OpenJDK 11
 update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 


### PR DESCRIPTION
Updated the ETF installation file to be compatible with both the new OsGeoLive 17 and JDK 11.

Updated user identification and assignation on folders permits.

Updated Java version and check for it before installing.

Ensure the java Version is the one required in both the start and stop script.

Changed version date and added maintainer label