### PR TITLE
Changed user to SUDO_USER (whoami if it fails) and add info in the header about running as  sudo

### DIFF
--- a/bin/install_etf.sh
+++ b/bin/install_etf.sh
@@ -5,6 +5,7 @@
 # Author:  Guadaltel <guadaltel.com> | Daniel Martín Pérez de León <danielmartin@guadaltel.com>  
 # Version 2024-09-20
 #
+# This script must be run as sudo
 #############################################################################
 # Copyright (c) 2011-2019 The Open Source Geospatial Foundation and others.
 # Licensed under the GNU LGPL.
@@ -33,7 +34,7 @@ START=$(date +%M:%S)
 BUILD_DIR=`pwd`
 TMP="/tmp/build_etf"
 if [ -z "$USER_NAME" ] ; then
-   USER_NAME=$(whoami)
+   USER_NAME=${SUDO_USER:-$(whoami)}
 fi
 USER_HOME="/home/$USER_NAME"
 JETTY9_SCRIPT_NAME="jetty9"


### PR DESCRIPTION
Since now we know the script (should) ALWAYS be run as sudo, we have changed the script so it configures it to the SUDO_USER user or whoami if it fails.

We have also added info in the head of the script where we advise to run the script as sudo.